### PR TITLE
公開鍵ログイン実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,15 @@ Laravel Reverb を使うか pusher を使うかで変わってきます。
 ./vendor/bin/sail artisan reverb:start
 ```
 
-
+## ログイン
+### 一般ログイン
+以下のURLから公開鍵でログイン。管理者の公開鍵でも、管理画面へのログインはできません。
+```
+/login
+```
+### 管理者ログイン
+以下のURLから秘密鍵でログイン。Usersテーブルに存在するユーザー以外ログイン不可
+```
+/admin/login
+```
 

--- a/app/Http/Controllers/Admin/LoginController.php
+++ b/app/Http/Controllers/Admin/LoginController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
+use SymbolSdk\Facade\SymbolFacade;
+use SymbolSdk\CryptoTypes\PrivateKey;
+use App\Models\User;
+
+class LoginController extends Controller
+{
+    /**
+     * 秘密鍵を使用した管理者ログイン
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'private_key' => ['required', 'string', 'uppercase', 'size:64'],
+        ]);
+
+        $credentials = $request->only('private_key');
+
+        // TODO: rate limit or use LoginRequest
+        $facade = new SymbolFacade('testnet');
+        $account = $facade->createAccount(new PrivateKey($request->private_key));
+        if ($user = User::where('public_key', strval($account->publicKey))->first())
+        {
+            Auth('web')->login($user);
+            session([
+                'public_key' => Auth('web')->user()->public_key,
+                'address' => Auth('web')->user()->address,
+            ]);
+            return redirect()->route('admin.dashboard');
+        } else {
+            return back()->withErrors(['login' => 'Invalid private key']);
+        }
+    }
+}

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -11,6 +11,7 @@ use Inertia\Inertia;
 use Inertia\Response;
 use SymbolSdk\Facade\SymbolFacade;
 use SymbolSdk\CryptoTypes\PrivateKey;
+use SymbolSdk\CryptoTypes\PublicKey;
 use App\Models\User;
 
 class LoginController extends Controller
@@ -31,10 +32,10 @@ class LoginController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'private_key' => ['required', 'string', 'uppercase', 'size:64'],
+            'public_key' => ['required', 'string', 'uppercase', 'size:64'],
         ]);
 
-        $credentials = $request->only('private_key');
+        $credentials = $request->only('public_key');
 
         if (Auth('symbol')->attempt($credentials))
         {
@@ -46,7 +47,7 @@ class LoginController extends Controller
             // 管理者であれば、Admin にログイン
             // TODO: rate limit or use LoginRequest
             $facade = new SymbolFacade('testnet');
-            $account = $facade->createAccount(new PrivateKey($request->private_key));
+            $account = $facade->createPublicAccount(new PublicKey($credentials['public_key']));
             if ($user = User::where('public_key', strval($account->publicKey))->first())
             {
                 Auth('web')->login($user);

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -44,16 +44,6 @@ class LoginController extends Controller
                 'address' => Auth('symbol')->user()->address,
             ]);
 
-            // 管理者であれば、Admin にログイン
-            // TODO: rate limit or use LoginRequest
-            $facade = new SymbolFacade('testnet');
-            $account = $facade->createPublicAccount(new PublicKey($credentials['public_key']));
-            if ($user = User::where('public_key', strval($account->publicKey))->first())
-            {
-                Auth('web')->login($user);
-                return redirect()->route('admin.dashboard');
-            }
-
             return redirect()->route('/');
         }
 

--- a/app/Providers/SymbolAccountProvider.php
+++ b/app/Providers/SymbolAccountProvider.php
@@ -51,16 +51,16 @@ class SymbolAccountProvider extends ServiceProvider implements UserProvider
     {
         try
         {
+            // 公開鍵からアカウント情報を作成
             $facade = new SymbolFacade('testnet');
-            $account = $facade->createAccount(new PrivateKey($credentials['private_key']));
-    
+            $account = $facade->createPublicAccount(new PublicKey($credentials['public_key']));
+
             return new SymbolAccount([
                 'public_key' => strval($account->publicKey),
                 'address' => strval($account->address),
             ]);
-
         }
-        catch (\Exception $e)
+            catch (\Exception $e)
         {
             return null;
         }
@@ -70,10 +70,7 @@ class SymbolAccountProvider extends ServiceProvider implements UserProvider
     {
         try
         {
-            $facade = new SymbolFacade('testnet');
-            $account = $facade->createAccount(new PrivateKey($credentials['private_key']));
-
-            return $user->getAuthIdentifier() === strval($account->publicKey);
+            return $user->getAuthIdentifier() === $credentials['public_key'];
         }
         catch (\Exception $e)
         {

--- a/resources/ts/Pages/Admin/Login.tsx
+++ b/resources/ts/Pages/Admin/Login.tsx
@@ -10,14 +10,14 @@ declare var route
 
 export default function Login({ status, canResetPassword }) {
     const { data, setData, post, processing, errors, reset } = useForm({
-        public_key: '',
+        private_key: '',
     });
 
     const submit = (e) => {
         e.preventDefault();
 
-        post(route('login'), {
-            onFinish: () => reset('public_key'),
+        post(route('admin.login'), {
+            onFinish: () => reset('private_key'),
         });
     };
 
@@ -33,19 +33,19 @@ export default function Login({ status, canResetPassword }) {
 
             <form onSubmit={submit}>
                 <div>
-                    <InputLabel htmlFor="public_key" value="Public Key" />
+                    <InputLabel htmlFor="private_key" value="Private Key" />
 
                     <TextInput
-                        id="public_key"
+                        id="private_key"
                         type="password"
-                        name="public_key"
-                        value={data.public_key}
+                        name="private_key"
+                        value={data.private_key}
                         className="mt-1 block w-full"
                         isFocused={true}
-                        onChange={(e) => setData('public_key', e.target.value)}
+                        onChange={(e) => setData('private_key', e.target.value)}
                     />
 
-                    <InputError message={errors.public_key} className="mt-2" />
+                    <InputError message={errors.private_key} className="mt-2" />
                 </div>
 
                 <div className="mt-4 flex items-center justify-end">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -6,7 +6,13 @@ use Inertia\Inertia;
 use App\Http\Controllers\Admin\ProfileController;
 use App\Http\Controllers\Admin\ElectionController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\LoginController;
 
+Route::get('/admin/login', function () {
+    return Inertia::render('Admin/Login');
+});
+
+Route::post('/admin/login', [LoginController::class, 'store'])->name('admin.login');
 
 Route::group(['middleware' => 'auth:web', 'prefix' => 'admin', 'as' => 'admin.'], function ()
 {


### PR DESCRIPTION
## 実装内容
### 従来のログインを秘密鍵から公開鍵ログインに変更
- 画面URL
```
/login
```

- バックエンドAPI
```
POST /login ........... LoginController@store
```

- 詳細
主に以下2ファイルを修正し、秘密鍵から公開鍵ログインに変更した。
なお公開鍵は誰でも知り得るため、本APIからは一般ログインしか行えない仕様とした。
symbolガードにて実装。
app/Http/Controllers/LoginController.php
app/Providers/SymbolAccountProvider.php

### 管理者ログインを新規追加
- 画面URL
```
/admin/login
```
- バックエンドAPI
```
POST /admin/login ........... Admin\LoginController@store
```

- 詳細
秘密鍵を使用した管理者ログインを新規作成。
既存のコードを踏襲しwebガードにて実装。